### PR TITLE
Custom sort value field

### DIFF
--- a/sortedm2m/fields.py
+++ b/sortedm2m/fields.py
@@ -77,7 +77,7 @@ def create_sorted_many_related_manager(superclass, rel):
             # intermediary's meta options.
             return super(SortedRelatedManager, self).\
                 get_query_set().\
-                extra(order_by=['%s.%s' % (
+                extra(order_by=['%s.`%s`' % (
                     rel.through._meta.db_table,
                     rel.through._sort_field_name,
                 )])


### PR DESCRIPTION
I prefer using a different field name for the sort field.  I actually migrated from a different sortable app and didn't want to change the field name.

This adds a `SORTEDM2M_FIELD_NAME` setting which allows the field name to be overridden.  I also added an escape for the field name when querying so reserved names like "order" can be used.

I intended to add tests for this feature before creating a pull request but I never got around to it.  I'm creating this pull request to at least start the discussion about this feature.
