### PR TITLE
Incompatibility with Django 1.5: AttributeError: 'Options' object has no attribute 'duplicate_targets'

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 * Sean O'Connor
 * Flavio Curella
 * Florian Ilgenfritz
+* Antti Kaihola

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+post-0.4.0
+----------
+
+* Fixed issue #8 - another obstacle to Django 1.5 support
+
 0.4.0
 -----
 

--- a/sortedm2m/fields.py
+++ b/sortedm2m/fields.py
@@ -229,11 +229,12 @@ class SortedManyToManyField(ManyToManyField):
                 field.rel.through = model
             add_lazy_relation(cls, self, self.rel.through, resolve_through_model)
 
-        if isinstance(self.rel.to, basestring):
-            target = self.rel.to
-        else:
-            target = self.rel.to._meta.db_table
-        cls._meta.duplicate_targets[self.column] = (target, "m2m")
+        if hasattr(cls._meta, 'duplicate_targets'):  # Django<1.5
+            if isinstance(self.rel.to, basestring):
+                target = self.rel.to
+            else:
+                target = self.rel.to._meta.db_table
+            cls._meta.duplicate_targets[self.column] = (target, "m2m")
 
     def formfield(self, **kwargs):
         defaults = {}


### PR DESCRIPTION
Django's commit django/django@68847135bc9acb2c51c2d36797d0a85395f0cd35 breaks django-sortedm2m:

```
Traceback (most recent call last):
  File "django/core/management/base.py", line 222, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "django/core/management/base.py", line 251, in execute
    self.validate()
  File "django/core/management/base.py", line 277, in validate
    num_errors = get_validation_errors(s, app)
  File "django/core/management/validation.py", line 34, in get_validation_errors
    for (app_name, error) in get_app_errors().items():
  File "django/db/models/loading.py", line 165, in get_app_errors
    self._populate()
  File "django/db/models/loading.py", line 71, in _populate
    self.load_app(app_name, True)
  File "django/db/models/loading.py", line 95, in load_app
    models = import_module('.models', app_name)
  File "django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "myproject/myapp/models.py", line 10, in <module>
    class MyModel(models.Model):
  File "django/db/models/base.py", line 136, in __new__
    new_class.add_to_class(obj_name, obj)
  File "django/db/models/base.py", line 256, in add_to_class
    value.contribute_to_class(cls, name)
  File "sortedm2m/fields.py", line 236, in contribute_to_class
    cls._meta.duplicate_targets[self.column] = (target, "m2m")
AttributeError: 'Options' object has no attribute 'duplicate_targets'
AttributeError: 'Options' object has no attribute 'duplicate_targets'
```

The commit message for django/django@68847135bc9acb2c51c2d36797d0a85395f0cd35 is:

```
commit 68847135bc9acb2c51c2d36797d0a85395f0cd35
Author: Anssi Kääriäinen <akaariai@gmail.com>
Date:   Fri Aug 10 22:00:21 2012 +0300

    Removed dupe_avoidance from sql/query and sql/compiler.py

    The dupe avoidance logic was removed as it doesn't seem to do anything,
    it is complicated, and it has nearly zero documentation.

    The removal of dupe_avoidance allowed for refactoring of both the
    implementation and signature of Query.join(). This refactoring cascades
    again to some other parts. The most significant of them is the changes
    in qs.combine(), and compiler.select_related_descent().
```
