### PR TITLE
Incompatibility with Django 1.5: AttributeError: 'QuerySet' object has no attribute '_pk_val'

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 * Sean O'Connor
 * Flavio Curella
 * Florian Ilgenfritz
+* Antti Kaihola

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+post-0.4.0
+----------
+
+* Fixed issue #10 - an obstacle to Django 1.5 support
+
 0.4.0
 -----
 


### PR DESCRIPTION
Django's commit django/django@611c4d6f1c24763e5e6e331a5dcf9b610288aaa8 breaks django-sortedm2m:

```
Traceback (most recent call last):
  File "sortedm2m/fields.py", line 180, in __set__
    manager.add(*value)
  File "django/db/models/fields/related.py", line 642, in add
    self._add_items(self.source_field_name, self.target_field_name, *objs)
  File "sortedm2m/fields.py", line 108, in _add_items
    source_field_name: self._pk_val,
  File "model_utils/managers.py", line 131, in __getattr__
    return getattr(self.get_query_set(), name)
AttributeError: 'QuerySet' object has no attribute '_pk_val'
```

The commit message for django/django@611c4d6f1c24763e5e6e331a5dcf9b610288aaa8 is:

```
commit 611c4d6f1c24763e5e6e331a5dcf9b610288aaa8
Author: Anssi Kääriäinen <akaariai@gmail.com>
Date:   Sun Oct 28 16:47:07 2012 +0200

    Fixed #18823 -- Ensured m2m.clear() works when using through+to_field

    There was a potential data-loss issue involved -- when clearing
    instance's m2m assignments it was possible some other instance's
    m2m data was deleted instead.

    This commit also improved None handling for to_field cases.
```
