### PR TITLE
label tag fixes in template for valid html rendering

### DIFF
--- a/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
+++ b/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
@@ -8,11 +8,11 @@
 
     <ul>
     {% for row in selected %}
-        <li><label {{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
+        <li><label{{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
     {% endfor %}
 
     {% for row in unselected %}
-        <li><label {{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
+        <li><label{{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
     {% endfor %}
     </ul>
 


### PR DESCRIPTION
1. Fix problem when `for="some_id"` renders to `for=&quot;some_id&quot;`
2. Fix extra space in label tag
