### PR TITLE
Django 2.2 support: updates function signature of `_add_items()` to allow the `through_defaults` kwarg added in Django 2.2

### DIFF
--- a/sortedm2m/fields.py
+++ b/sortedm2m/fields.py
@@ -92,10 +92,11 @@ def create_sorted_many_related_manager(superclass, rel, *args, **kwargs):
             super(SortedRelatedManager, self).set(objs, **kwargs)
         set.alters_data = True
 
-        def _add_items(self, source_field_name, target_field_name, *objs):
+        def _add_items(self, source_field_name, target_field_name, *objs, **kwargs):
             # source_field_name: the PK fieldname in join table for the source object
             # target_field_name: the PK fieldname in join table for the target object
             # *objs - objects to add. Either object instances, or primary keys of object instances.
+            # **kwargs: in Django >= 2 contains `through_defaults` key.
 
             # If there aren't any objects, there is nothing to do.
             from django.db.models import Max, Model


### PR DESCRIPTION
When I recently upgraded from Django 2.1 to 2.2 (Python 3.7) I was getting the following error:

> TypeError: _add_items() got an unexpected keyword argument 'through_defaults'

It appears that Django 2.2 [added the `through_defaults` kwarg](https://github.com/django/django/blob/2.2a1/django/db/models/fields/related_descriptors.py#L965) to `_add_items()` and calls to it.

`_add_items()` was overwritten in the `SortedRelatedManager` and the method signature doesn't support the new `through_defaults` kwarg.

I've added a generic `**kwargs` catchall to prevent the type error. I'm not sure how `through_defaults` is used so I didn't attempt to update the method body to support it. It looks like it's mostly `None` anyway.