### PR TITLE
Updated Travis deploy constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ deploy:
   on:
     tags: true
     repo: jazzband/django-sortedm2m
-    condition: "$TOXENV = py36-22"
+    python: 3.7


### PR DESCRIPTION
Travis doesn't know about Tox environment variables, so we should deploy after the Python 3.7 build succeeds.