### PR TITLE
Remove `admin/js/jquery.init.js` from `SortedCheckboxSelectMultiple`

### DIFF
--- a/sortedm2m/forms.py
+++ b/sortedm2m/forms.py
@@ -13,7 +13,6 @@ from django.utils.six import string_types
 class SortedCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
     class Media:
         js = (
-            'admin/js/jquery.init.js',
             'sortedm2m/widget.js',
             'sortedm2m/jquery-ui.js',
         )


### PR DESCRIPTION
`jquery.init.js` seems to be used by Django's admin templates to remap `$` into `django.jQuery`, and then _remove `$` from the global scope_. Its contents are:

```js
var django=django||{};django.jQuery=jQuery.noConflict(true);
```

(See https://api.jquery.com/jQuery.noConflict/.) This means that including a `SortedCheckboxSelectMultiple` widget on a page that expects jQuery to be accessible under `$` breaks code on that page.

This commit removes the loading of `jquery.init.js`, which fixes this issue. The existing code does not appear to be relying on its behaviour, and it was introduced recently in 19a11c99d97f4f991d4d45ab4615d747dabd25fe (without explicit justification that I could find).