### PR TITLE
Add Autoincrementing for reverse relationship modification

### DIFF
--- a/sortedm2m/fields.py
+++ b/sortedm2m/fields.py
@@ -342,7 +342,7 @@ def create_sortable_many_to_many_intermediary_model(field, klass, sort_field_nam
 
 
 def get_sortedm2m_autoincrement(sort_field_name):
-    def sortedm2m_autoincrement(sender, instance, action, reverse, model, pk_set, using, **kwargs):
+    def sortedm2m_autoincrement(sender, instance, action, reverse, model, pk_set, using, *args, **kwargs):
         """
         Autoincrement the sort field when a reverse relationship is modified
         """


### PR DESCRIPTION
When modifying a sortedm2m relationship from the "to" model admin, the default sort value of 0 is used, which means new instance is added to the top of the sorted list. Ideally, new records would be sorted last be default.

Adding an m2m_changed listener for the intermediate model allows us to make sure that new records have a sort value higher than the last item already in the list. 