### PR TITLE
Set realistic code coverage target.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
   status:
     patch:
       default:
-        target: 95
+        target: 75
     project:
       default:
-        target: 83
+        target: 75


### PR DESCRIPTION
The CI runs a check on code coverage. At present we are nowhere near the target and all recent PRs have failed this check.
I suggest reducing the % so that current PRs pass. This way we still check that PRs do not reduce coverage.
In future if someone wants to put a lot of TLC into this project, we can increase the values :-)