### PR TITLE
Changes necessary to get github actions checks passing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
         include:
           - python-version: '3.7'
             django-version: '3.2'
+        exclude:
+          - python-version: '3.8'
+            django-version: 'main'
+          - python-version: '3.9'
+            django-version: 'main'
 
     services:
       postgres:
@@ -68,7 +73,7 @@ jobs:
     - name: Install Selenium dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get -y install firefox-geckodriver xvfb
+        sudo apt-get -y install firefox xvfb
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Mucking around with this, I first got errors from selenium

```
Run sudo apt-get -qq update
Reading package lists...
Building dependency tree...
Reading state information...
Package firefox-geckodriver is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  firefox

E: Package 'firefox-geckodriver' has no installation candidate
Error: Process completed with exit code 100.
```

So this follows its advice and installs "firefox" as opposed to the geckodriver one.

Then you can fairly easy follow that django/django dropped support for python <3.10 in the PR here https://github.com/django/django/pull/16467, and since you are running against the main branch, this will fail checks as it fails to install. This solves this by adding `exclude:` to the matrix.