### PR TITLE
Fixed sortable widget not working in stacked inline admin

### DIFF
--- a/example/testapp/admin.py
+++ b/example/testapp/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from example.testapp.models import Car, ParkingArea
+from example.testapp.models import Car, Garage, ParkingArea
 
 
 class ParkingAreaAdmin(admin.ModelAdmin):
@@ -15,5 +15,15 @@ class ParkingAreaAdmin(admin.ModelAdmin):
     )
 
 
+class ParkingAreaInlineAdmin(admin.StackedInline):
+    model = ParkingArea
+    extra = 0
+
+
+class GarageAdmin(admin.ModelAdmin):
+    inlines = [ParkingAreaInlineAdmin]
+
+
 admin.site.register(Car)
+admin.site.register(Garage, GarageAdmin)
 admin.site.register(ParkingArea, ParkingAreaAdmin)

--- a/example/testapp/models.py
+++ b/example/testapp/models.py
@@ -16,8 +16,13 @@ class BaseCarThrough:
         return str(self.car) + " in " + str(self.parkingarea)  # pylint: disable=no-member
 
 
+class Garage(models.Model):
+    name = models.CharField(max_length=30)
+
+
 class ParkingArea(models.Model):
     name = models.CharField(max_length=50)
+    garage = models.ForeignKey(Garage, on_delete=models.CASCADE, null=True, blank=True, default=None)
     cars = SortedManyToManyField(Car, base_class=BaseCarThrough)
 
     def __str__(self):

--- a/sortedm2m/static/sortedm2m/widget.js
+++ b/sortedm2m/static/sortedm2m/widget.js
@@ -62,7 +62,9 @@ if (typeof jQuery === 'undefined') {
         }
 
         function iterateUl() {
-            $('.sortedm2m-items').each(function () {
+            // Add sortable only to visible .sortedm2m-items.
+            // Exclude element with class .sortedm2m since they are already initialized
+            $('.sortedm2m-items:visible:not(.sortedm2m)').each(function () {
                 var ul = $(this);
 
                 prepareUl(ul);


### PR DESCRIPTION
The draggable/sortable feature were not working for elements dynamically added using "Add another XYZ" link.