### PR TITLE
Fix error in field in Django 5.1

### DIFF
--- a/sortedm2m/fields.py
+++ b/sortedm2m/fields.py
@@ -232,7 +232,7 @@ class SortedManyToManyField(_ManyToManyField):
 
         if rel.symmetrical and (rel.model == "self" or rel.model == cls._meta.object_name):
             rel.related_name = "%s_rel_+" % name
-        elif rel.is_hidden():
+        elif rel.hidden:
             # If the backwards relation is disabled, replace the original
             # related_name with one generated from the m2m field name. Django
             # still uses backwards relations internally and we need to avoid


### PR DESCRIPTION
`ManyToManyRel.is_hidden()` has been removed in Django 5.1, leaving `ManyToManyRel.hidden`. This resulted in a fatal error when using django-sortedm2m in Django 5.1 where `is_hidden()` is used in `sortedm2m/fields.py`.

This commit replaces that call with use of the `hidden` property.

I haven't been able to run the tests on this. I've given the `test_project` a quick go with both Django 4.2 and 5.1 and it successfully starts up, which it didn't before the change.

For #214