### PR TITLE
feat: allow overriding widget template name

### DIFF
--- a/sortedm2m/admin.py
+++ b/sortedm2m/admin.py
@@ -1,7 +1,8 @@
 from django import forms
 from django.conf import settings
-from django.utils import translation
 from django.contrib.admin.widgets import AutocompleteSelectMultiple
+from django.utils import translation
+
 
 class OrderedAutocomplete(AutocompleteSelectMultiple):
     def optgroups(self, name, value, attr=None):
@@ -48,7 +49,7 @@ class OrderedAutocomplete(AutocompleteSelectMultiple):
     class Media:
         extra = "" if settings.DEBUG else ".min"
         lang = translation.get_language()
-        js = ( 
+        js = (
             "admin/js/vendor/jquery/jquery%s.js" % extra,
             "admin/js/vendor/select2/select2.full%s.js" % extra,
         ) + (

--- a/sortedm2m/fields.py
+++ b/sortedm2m/fields.py
@@ -55,7 +55,7 @@ def create_sorted_many_related_manager(superclass, rel, *args, **kwargs):
             # Force evaluation of `objs` in case it's a queryset whose value
             # could be affected by `manager.clear()`. Refs #19816.
             # objs = tuple(objs)
-            
+
             db = router.db_for_write(self.through, instance=self.instance)
             with transaction.atomic(using=db, savepoint=False):
                 old_ids = list(

--- a/sortedm2m/forms.py
+++ b/sortedm2m/forms.py
@@ -8,6 +8,8 @@ from django.utils.safestring import mark_safe
 
 
 class SortedCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
+    template_name = 'sortedm2m/sorted_checkbox_select_multiple_widget.html'
+
     class Media:
         js = (
             'admin/js/jquery.init.js',
@@ -72,7 +74,7 @@ class SortedCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
         selected = ordered
 
         html = render_to_string(
-            'sortedm2m/sorted_checkbox_select_multiple_widget.html',
+            self.template_name,
             {'selected': selected, 'unselected': unselected})
         return mark_safe(html)
 

--- a/sortedm2m/forms.py
+++ b/sortedm2m/forms.py
@@ -108,4 +108,4 @@ class SortedMultipleChoiceField(forms.ModelMultipleChoiceField):
 class SortedCheckboxMultipleChoiceField(SortedMultipleChoiceField):
     widget = SortedCheckboxSelectMultiple
 
-    
+


### PR DESCRIPTION
This allows customizing the widget for e.g. frontend templates and leaving the default widget used in Django Admin untouched.